### PR TITLE
docs: add SEO meta tags to docs/index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,47 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Thecore — Rails API & Admin Framework</title>
   <meta name="description" content="Thecore is a Ruby on Rails framework for building model-driven REST APIs and admin interfaces with zero boilerplate. Built on model_driven_api and thecore_ui_rails_admin." />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://gabrieletassoni.github.io/thecore/" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Thecore" />
+  <meta property="og:title" content="Thecore — Rails API & Admin Framework" />
+  <meta property="og:description" content="Thecore is a Ruby on Rails framework for building model-driven REST APIs and admin interfaces with zero boilerplate. Built on model_driven_api and thecore_ui_rails_admin." />
+  <meta property="og:url" content="https://gabrieletassoni.github.io/thecore/" />
+  <meta property="og:image" content="https://gabrieletassoni.github.io/thecore/images/logo.png" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Thecore — Rails API & Admin Framework" />
+  <meta name="twitter:description" content="Thecore is a Ruby on Rails framework for building model-driven REST APIs and admin interfaces with zero boilerplate. Built on model_driven_api and thecore_ui_rails_admin." />
+  <meta name="twitter:image" content="https://gabrieletassoni.github.io/thecore/images/logo.png" />
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Thecore",
+    "url": "https://gabrieletassoni.github.io/thecore/",
+    "description": "A Ruby on Rails framework for building model-driven REST APIs and admin interfaces with zero boilerplate. Built on model_driven_api and thecore_ui_rails_admin.",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Linux, macOS, Windows",
+    "programmingLanguage": "Ruby",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "Gabriele Tassoni",
+      "url": "https://github.com/gabrieletassoni"
+    }
+  }
+  </script>
+
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />


### PR DESCRIPTION
Add Open Graph, Twitter Card, canonical URL, robots meta, and
JSON-LD structured data (SoftwareApplication schema) to improve
search engine discoverability and social sharing link previews.

https://claude.ai/code/session_01NTbSXm22VZwvMTavGTVoa7